### PR TITLE
Fix minimizing to tray when requested by window manager

### DIFF
--- a/lib/google-music-electron.js
+++ b/lib/google-music-electron.js
@@ -15,7 +15,8 @@ var pkg = require('../package.json');
 program
   .version(pkg.version)
   .option('-S, --skip-taskbar', 'Skip showing the application in the taskbar')
-  .option('--hide-via-tray', 'Replace default minimize action with hiding the window')
+  .option('--minimize-to-tray', 'Hide window to tray instead of minimizing')
+  .option('--hide-via-tray', 'Hide window to tray instead of minimizing (only for tray icon)')
   .option('--verbose', 'Display verbose log output in stdout')
   .option('--debug-repl', 'Starts a `replify` server as `google-music-electron` for debugging')
   // Allow unknown Chromium flags
@@ -155,7 +156,7 @@ var gme = {
 };
 
 // Assign tray click behavior
-gme.onTrayClick = program.hideViaTray ? gme.toggleVisibility : gme.toggleMinimize;
+gme.onTrayClick = (program.hideViaTray || program.minimizeToTray) ? gme.toggleVisibility : gme.toggleMinimize;
 
 // When Electron is done loading
 app.on('ready', function handleReady () {
@@ -177,7 +178,7 @@ app.on('ready', function handleReady () {
   gme.browserWindow.loadUrl('https://play.google.com/music/listen');
 
   // If hiding to tray was requested, trigger a visibility toggle when the window is minimized
-  if (program.hideViaTray) {
+  if (program.minimizeToTray) {
     gme.browserWindow.on('minimize', gme.toggleVisibility);
   }
 

--- a/lib/google-music-electron.js
+++ b/lib/google-music-electron.js
@@ -176,6 +176,11 @@ app.on('ready', function handleReady () {
   gme.browserWindow = new BrowserWindow(windowOpts);
   gme.browserWindow.loadUrl('https://play.google.com/music/listen');
 
+  // If hiding to tray was requested, trigger a visibility toggle when the window is minimized
+  if (program.hideViaTray) {
+    gme.browserWindow.on('minimize', gme.toggleVisibility);
+  }
+
   // When our window is closed, clean up the reference to our window
   gme.browserWindow.on('closed', function handleWindowClose () {
     logger.debug('Browser window closed, garbage collecting `browserWindow`');


### PR DESCRIPTION
Hi Todd,

First of all, thanks for your work on this application!

I'm skimming through the commit history and I keep wondering why have you abandoned support for minimizing the window to tray when it is requested by the window manager (first implemented in e132f7c). Introducing the change from this pull request made it work for me (in XFCE 4.12) and didn't break "normal" minimization when `--hide-via-tray` is not supplied. Clicking on the tray icon also results in the desired behavior in both minimization modes.

What do you think? Am I missing something here?
