### PR TITLE
Fix license to the SPDX License format

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "email": "todd@twolfson.com",
     "url": "http://twolfson.com/"
   },
-  "license": "Unlicense",
   "repository": {
     "type": "git",
     "url": "git://github.com/twolfson/google-music-electron.git"
@@ -16,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/twolfson/google-music-electron/issues"
   },
-  "licenses": [
-    {
-      "type": "UNLICENSE",
-      "url": "https://github.com/twolfson/google-music-electron/blob/master/UNLICENSE"
-    }
-  ],
+  "license": "Unlicense",
   "main": "lib/google-music-electron",
   "engines": {
     "node": ">= 0.10.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "email": "todd@twolfson.com",
     "url": "http://twolfson.com/"
   },
+  "license": "Unlicense",
   "repository": {
     "type": "git",
     "url": "git://github.com/twolfson/google-music-electron.git"


### PR DESCRIPTION
Removes the following warning by adding license data from http://spdx.org/licenses/Unlicense.html:

<img width="557" alt="screen shot 2015-10-30 at 2 39 40 pm" src="https://cloud.githubusercontent.com/assets/432489/10856206/1c2b1632-7f14-11e5-9957-b413af3be497.png">
