### PR TITLE
Added keyboard mappings for Mac OSX

### DIFF
--- a/lib/menus/darwin.json
+++ b/lib/menus/darwin.json
@@ -21,32 +21,32 @@
     "label": "Edit",
     "submenu": [{
       "label": "Undo",
-      "accelerator": "CmdOrCtrl+Z",
-      "selector": "undo:"
+      "selector": "undo:",
+      "accelerator": "Command+Z"
     }, {
       "label": "Redo",
-      "accelerator": "Shift+CmdOrCtrl+Z",
-      "selector": "redo:"
+      "selector": "redo:",
+      "accelerator": "Shift+Command+Z"
     }, {
       "type": "separator"
     }, {
       "label": "Cut",
-      "accelerator": "CmdOrCtrl+X",
-      "selector": "cut:"
+      "selector": "cut:",
+      "accelerator": "Command+X"
     }, {
       "label": "Copy",
-      "accelerator": "CmdOrCtrl+C",
-      "selector": "copy:"
+      "selector": "copy:",
+      "accelerator": "Command+C"
     }, {
       "label": "Paste",
-      "accelerator": "CmdOrCtrl+V",
-      "selector": "paste:" 
+      "selector": "paste:",
+      "accelerator": "Command+V"
     }, {
       "label": "Select All",
-      "accelerator": "CmdOrCtrl+A",
-      "selector": "selectAll:"
+      "selector": "selectAll:",
+      "accelerator": "Command+A"
     }]
-  },{
+  }, {
     "label": "View",
     "submenu": [{
       "label": "Reload",

--- a/lib/menus/darwin.json
+++ b/lib/menus/darwin.json
@@ -18,6 +18,35 @@
       "accelerator": "Command+Q"
     }]
   }, {
+    "label": "Edit",
+    "submenu": [{
+      "label": "Undo",
+      "accelerator": "CmdOrCtrl+Z",
+      "selector": "undo:"
+    }, {
+      "label": "Redo",
+      "accelerator": "Shift+CmdOrCtrl+Z",
+      "selector": "redo:"
+    }, {
+      "type": "separator"
+    }, {
+      "label": "Cut",
+      "accelerator": "CmdOrCtrl+X",
+      "selector": "cut:"
+    }, {
+      "label": "Copy",
+      "accelerator": "CmdOrCtrl+C",
+      "selector": "copy:"
+    }, {
+      "label": "Paste",
+      "accelerator": "CmdOrCtrl+V",
+      "selector": "paste:" 
+    }, {
+      "label": "Select All",
+      "accelerator": "CmdOrCtrl+A",
+      "selector": "selectAll:"
+    }]
+  },{
     "label": "View",
     "submenu": [{
       "label": "Reload",

--- a/lib/menus/linux.json
+++ b/lib/menus/linux.json
@@ -10,6 +10,35 @@
       "accelerator": "Control+Q"
     }]
   }, {
+    "label": "&Edit",
+    "submenu": [{
+      "label": "&Undo",
+      "command": "core:undo",
+      "accelerator": "Control+Z"
+    }, {
+      "label": "&Redo",
+      "command": "core:redo",
+      "accelerator": "Control+Y"
+    }, {
+      "type": "separator"
+    }, {
+      "label": "&Cut",
+      "command": "core:cut",
+      "accelerator": "Control+X"
+    }, {
+      "label": "C&opy",
+      "command": "core:copy",
+      "accelerator": "Control+C"
+    }, {
+      "label": "&Paste",
+      "command": "core:paste",
+      "accelerator": "Control+V"
+    }, {
+      "label": "Select &All",
+      "command": "core:select-all",
+      "accelerator": "Control+A"
+    }]
+  }, {
     "label": "&View",
     "submenu": [{
       "label": "&Reload",

--- a/lib/menus/win32.json
+++ b/lib/menus/win32.json
@@ -12,6 +12,35 @@
       "accelerator": "Alt+F4"
     }]
   }, {
+    "label": "&Edit",
+    "submenu": [{
+      "label": "&Undo",
+      "command": "core:undo",
+      "accelerator": "Control+Z"
+    }, {
+      "label": "&Redo",
+      "command": "core:redo",
+      "accelerator": "Control+Y"
+    }, {
+      "type": "separator"
+    }, {
+      "label": "&Cut",
+      "command": "core:cut",
+      "accelerator": "Control+X"
+    }, {
+      "label": "C&opy",
+      "command": "core:copy",
+      "accelerator": "Control+C"
+    }, {
+      "label": "&Paste",
+      "command": "core:paste",
+      "accelerator": "Control+V"
+    }, {
+      "label": "Select &All",
+      "command": "core:select-all",
+      "accelerator": "Control+A"
+    }]
+  }, {
     "label": "&View",
     "submenu": [{
       "label": "&Reload",


### PR DESCRIPTION
On OSX the keyboard shortcuts for selecting all, cutting, pasting, undo, redo are not implemented by default. this Pull request will add those keyboard commands into darwin so that they will work again. 
