### PR TITLE
Adds saving of window size (and position) for #32

### DIFF
--- a/lib/google-music-electron.js
+++ b/lib/google-music-electron.js
@@ -208,7 +208,6 @@ function launchGme() {
     // Load in our Google Music bindings on the page
     preload: __dirname + '/browser.js',
     'skip-taskbar': config.get('skip-taskbar'),
-    'use-content-size': true,
     width: windowInfo.width,
     x: windowInfo.x,
     y: windowInfo.y

--- a/lib/google-music-electron.js
+++ b/lib/google-music-electron.js
@@ -226,12 +226,17 @@ function launchGme() {
     gme.browserWindow.on('minimize', gme.toggleVisibility);
   }
 
-  // When we recieve the close event, before we clean up, save the current size and position of the window
-  // DEV: Note this fires when we still have access to the browserWindow, before 'closed'
-  gme.browserWindow.on('close', function handleCloseEvent () {
+  // Save the window position after moving
+  gme.browserWindow.on('move', _.debounce(function handleWindowMove () {
+    logger.debug('Setting window position in config.');
+    config.set('window-info', gme.browserWindow.getBounds());
+  }, 250));
+
+  // Save the window size after resizing
+  gme.browserWindow.on('resize', _.debounce(function handleWindowResize () {
     logger.debug('Setting window size in config.');
     config.set('window-info', gme.browserWindow.getBounds());
-  });
+  }, 250));
 
   // When our window is closed, clean up the reference to our window
   gme.browserWindow.on('closed', function handleWindowClose () {

--- a/lib/google-music-electron.js
+++ b/lib/google-music-electron.js
@@ -193,15 +193,25 @@ gme.onRaise = (config.get('hide-via-tray') || config.get('minimize-to-tray')) ?
 
 // Define our launch handler
 function launchGme() {
+  // Check for previous window info in config
+  var windowInfo = config.get('window-info');
+  if (!windowInfo) {
+    windowInfo = {
+      height: 920,
+      width: 1024
+    };
+  }
   // Create our browser window for Google Music
   var windowOpts = {
-    height: 920,
+    height: windowInfo.height,
     icon: assets['icon-32'],
     // Load in our Google Music bindings on the page
     preload: __dirname + '/browser.js',
     'skip-taskbar': config.get('skip-taskbar'),
     'use-content-size': true,
-    width: 1024
+    width: windowInfo.width,
+    x: windowInfo.x,
+    y: windowInfo.y
   };
   logger.info('App ready. Opening Google Music window', {
     options: windowOpts,
@@ -215,6 +225,13 @@ function launchGme() {
   if (config.get('minimize-to-tray')) {
     gme.browserWindow.on('minimize', gme.toggleVisibility);
   }
+
+  // When we recieve the close event, before we clean up, save the current size and position of the window
+  // DEV: Note this fires when we still have access to the browserWindow, before 'closed'
+  gme.browserWindow.on('close', function handleCloseEvent () {
+    logger.debug('Setting window size in config.');
+    config.set('window-info', gme.browserWindow.getBounds());
+  });
 
   // When our window is closed, clean up the reference to our window
   gme.browserWindow.on('closed', function handleWindowClose () {


### PR DESCRIPTION
Hey there!

I thought I'd take a shot at clearing up #32, although it looks like setting window state (maximized etc) on creation is a little trickier than just the size and position, so in the meantime here's the size and position saved on the close event, and then read when the browserWindow is created if it's there.

Hope this is the kind of thing that you're expecting.

Thanks,
Jordan
